### PR TITLE
Added folder var to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+var/
 vendor/
 composer.lock
 .stuff/


### PR DESCRIPTION
Ignore folder "var".
Using `make analysis-code` creates folder var with lots of temporary and cache files. We do not need them in git. 