### PR TITLE
Removed incompatible simfony 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
     "psr/http-client": "^1.0",
     "psr/http-client-implementation": "^1.0",
     "guzzlehttp/psr7": "^2.0",
-    "symfony/uid": "^5.3|^6.0|^7.0",
-    "symfony/serializer": "^5.3|^6.0|^7.0",
-    "symfony/property-access": "^5.3|^6.0|^7.0",
+    "symfony/uid": "^6.0|^7.0",
+    "symfony/serializer": "^6.0|^7.0",
+    "symfony/property-access": "^6.0|^7.0",
     "phpstan/phpdoc-parser": "^1.0|^2.0",
     "phpdocumentor/reflection-docblock": "^5.0|^6.0",
     "doctrine/annotations": "^1.0|^2.0",
@@ -42,7 +42,7 @@
     "brick/phonenumber": "^0.4|^0.5|^0.6|^0.7|^0.8"
   },
   "require-dev": {
-    "symfony/var-dumper": "^5.3|^6.0|^7.0",
+    "symfony/var-dumper": "^6.0|^7.0",
     "friendsofphp/php-cs-fixer": "^3.64",
     "vimeo/psalm": "^5.23",
     "psalm/plugin-symfony": "^5.1",


### PR DESCRIPTION
Symfony 5.3 incompatible with  "friendsofphp/php-cs-fixer": "^3.64". I assume, no one using such combination. So, my proposal is to remove Symfony 5.3. Although, alternative is to downgrade php-cs-fixer.