### PR TITLE
Fix symfony property info phpstan extractor compatibility version

### DIFF
--- a/src/Infrastructure/PropertyInfo/Extractor/PollyfillPhpStanExtractor.php
+++ b/src/Infrastructure/PropertyInfo/Extractor/PollyfillPhpStanExtractor.php
@@ -78,7 +78,7 @@ final class PollyfillPhpStanExtractor implements PropertyTypeExtractorInterface,
         $this->accessorPrefixes     = $accessorPrefixes ?? ReflectionExtractor::$defaultAccessorPrefixes;
         $this->arrayMutatorPrefixes = $arrayMutatorPrefixes ?? ReflectionExtractor::$defaultArrayMutatorPrefixes;
 
-        if (class_exists(ParserConfig::class)) { //PhpStan 2.0
+        if (class_exists(ParserConfig::class)) { // PhpStan 2.0
             $config             = new ParserConfig([]);
             $this->lexer        = new Lexer($config);
             $this->phpDocParser = new PhpDocParser(

--- a/src/Infrastructure/PropertyInfo/Extractor/PollyfillPhpStanExtractor.php
+++ b/src/Infrastructure/PropertyInfo/Extractor/PollyfillPhpStanExtractor.php
@@ -23,6 +23,7 @@ use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\PhpDocParser\Parser\TokenIterator;
 use PHPStan\PhpDocParser\Parser\TypeParser;
+use PHPStan\PhpDocParser\ParserConfig;
 use Symfony\Component\PropertyInfo\Extractor\ConstructorArgumentTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
@@ -77,8 +78,18 @@ final class PollyfillPhpStanExtractor implements PropertyTypeExtractorInterface,
         $this->accessorPrefixes     = $accessorPrefixes ?? ReflectionExtractor::$defaultAccessorPrefixes;
         $this->arrayMutatorPrefixes = $arrayMutatorPrefixes ?? ReflectionExtractor::$defaultArrayMutatorPrefixes;
 
-        $this->phpDocParser     = new PhpDocParser(new TypeParser(new ConstExprParser()), new ConstExprParser());
-        $this->lexer            = new Lexer();
+        if (class_exists(ParserConfig::class)) { //PhpStan 2.0
+            $config             = new ParserConfig([]);
+            $this->lexer        = new Lexer($config);
+            $this->phpDocParser = new PhpDocParser(
+                $config,
+                new TypeParser($config, new ConstExprParser($config)),
+                new ConstExprParser($config)
+            );
+        } else {
+            $this->lexer        = new Lexer();
+            $this->phpDocParser = new PhpDocParser(new TypeParser(new ConstExprParser()), new ConstExprParser());
+        }
         $this->nameScopeFactory = new NameScopeFactory();
     }
 

--- a/src/RestClientBuilder.php
+++ b/src/RestClientBuilder.php
@@ -98,12 +98,12 @@ final class RestClientBuilder
         $typeExtractors       = [];
 
         /* @infection-ignore-all */
-        if (isOldPackage('symfony/property-info', '7.1.8')) {
+        if (isOldPackage('symfony/property-info', '7.1.7')) {
             $typeExtractors[] = new PollyfillPhpStanExtractor();
         }
 
         /* @infection-ignore-all */
-        if (!isOldPackage('symfony/property-info', '7.1.8')) {
+        if (!isOldPackage('symfony/property-info', '7.1.7')) {
             $typeExtractors[] = new PhpStanExtractor();
         }
 

--- a/src/RestClientBuilder.php
+++ b/src/RestClientBuilder.php
@@ -98,12 +98,12 @@ final class RestClientBuilder
         $typeExtractors       = [];
 
         /* @infection-ignore-all */
-        if (isOldPackage('symfony/property-info', '7.1.7')) {
+        if (isOldPackage('symfony/property-info', '7.1.8')) {
             $typeExtractors[] = new PollyfillPhpStanExtractor();
         }
 
         /* @infection-ignore-all */
-        if (!isOldPackage('symfony/property-info', '7.1.7')) {
+        if (!isOldPackage('symfony/property-info', '7.1.8')) {
             $typeExtractors[] = new PhpStanExtractor();
         }
 

--- a/src/RestClientBuilder.php
+++ b/src/RestClientBuilder.php
@@ -98,12 +98,12 @@ final class RestClientBuilder
         $typeExtractors       = [];
 
         /* @infection-ignore-all */
-        if (isOldPackage('symfony/property-info', '6.1')) {
+        if (isOldPackage('symfony/property-info', '7.1.8')) {
             $typeExtractors[] = new PollyfillPhpStanExtractor();
         }
 
         /* @infection-ignore-all */
-        if (!isOldPackage('symfony/property-info', '6.1')) {
+        if (!isOldPackage('symfony/property-info', '7.1.8')) {
             $typeExtractors[] = new PhpStanExtractor();
         }
 


### PR DESCRIPTION
Added support for phpstan/phpdoc-parser 2.0
And fix for symfony/property-info, which only since 7.1.8 have proper support for phpstan/phpdoc-parser 2.0.